### PR TITLE
Design standalone daemon structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # 42minutes
 
-42 minutes is a collection of tools to manage your tv-series collection.  
-It consists of a cliemt, server, and user interface.
+42minutes is a collection of tools to manage your tv-series collection.  
+It consists of a client, server, and user interface.
+
+In addition to these there is a single user daemon that wraps server and
+client into a single binary, requires no authentication, and meant to be
+used by a single user.
+
+__The standalone daemon is the first thing 42minutes will focus on.__
 
 ## client
 

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -15,12 +15,13 @@ type daemon struct {
 	finder     minutes.Finder
 	downloader minutes.Downloader
 	differ     minutes.Differ
+	matcher    minutes.Matcher
 }
 
 // HandleWatcherNotification handles watcher notifications
-func (d *daemon) HandleWatcherNotification(notifType minutes.NotificationType, file string) {
+func (d *daemon) HandleWatcherNotification(notifType minutes.NotificationType, filename string) {
 	// find episode, season, and show
-	epis, _ := d.glibrary.QueryEpisodesByFile(file)
+	epis, _ := d.matcher.Match(filename)
 	seas, _ := d.glibrary.GetSeason(epis[0].SeasonID)
 	show, _ := d.glibrary.GetShow(epis[0].ShowID)
 	// make sure they are in the user's library
@@ -70,6 +71,9 @@ func main() {
 	// simple differ
 	diff := &minutes.SimpleDiff{}
 
+	// simple matcher
+	mtch, _ := minutes.NewSimpleMatch(glib)
+
 	// standalone daemon
 	daem := &daemon{
 		glibrary:   glib,
@@ -77,6 +81,7 @@ func main() {
 		finder:     fndr,
 		downloader: dwnl,
 		differ:     diff,
+		matcher:    mtch,
 	}
 
 	// create a new file watcher

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	minutes "github.com/42minutes/go-42minutes"
+	trakt "github.com/42minutes/go-trakt"
+	"github.com/dancannon/gorethink"
+)
+
+// daemon implements the WatchNotifier interface so it can be notified for
+// updates
+type daemon struct {
+	watcher    minutes.Watcher
+	glibrary   minutes.Library
+	ulibrary   minutes.Library
+	finder     minutes.Finder
+	downloader minutes.Downloader
+	differ     minutes.Differ
+}
+
+// HandleWatcherNotification handles watcher notifications
+func (d *daemon) HandleWatcherNotification(notifType minutes.NotificationType, file string) {
+	// find episode, season, and show
+	epis, _ := d.glibrary.QueryEpisodesByFile(file)
+	seas, _ := d.glibrary.GetSeason(epis[0].SeasonID)
+	show, _ := d.glibrary.GetShow(epis[0].ShowID)
+	// make sure they are in the user's library
+	d.ulibrary.UpsertShow(show)
+	d.ulibrary.UpsertSeason(seas)
+	d.ulibrary.UpsertEpisode(epis[0])
+}
+
+// Diff will attempt to figure out which episodes are missing from
+// the user's library, find their torrents and download them
+func (d *daemon) Diff() {
+	shows, _ := d.ulibrary.GetShows()
+	for _, ushow := range shows {
+		gshow, _ := d.glibrary.GetShow(ushow.ID)
+		epis, _ := d.differ.Diff(ushow, gshow)
+		for _, epi := range epis {
+			torr, _ := d.finder.Find(epi)
+			d.downloader.Download(torr[0])
+		}
+	}
+}
+
+func main() {
+	// trakt.tv client
+	trkt := trakt.NewClient(
+		"CLIENT_ID",
+		trakt.TokenAuth{AccessToken: "ACCESS_TOKEN"},
+	)
+
+	// global ro trakt library
+	glib := minutes.NewTraktLibrary(trkt)
+
+	// rethinkdb session
+	redb, _ := gorethink.Connect(gorethink.ConnectOpts{
+		Address: "localhost",
+	})
+
+	// user rw library for single hardcoded user id
+	ulib := minutes.NewUserLibrary(redb, "me")
+
+	// torrent finder
+	fndr := &minutes.TorrentFinder{}
+
+	// torrent download manager
+	dwnl := &minutes.DownloaderTorrent{}
+
+	// simple differ
+	diff := &minutes.SimpleDiff{}
+
+	// standalone daemon
+	daem := &daemon{
+		glibrary:   glib,
+		ulibrary:   ulib,
+		finder:     fndr,
+		downloader: dwnl,
+		differ:     diff,
+	}
+
+	// create a new file watcher
+	wtch := &minutes.FileWatcher{}
+	// notify daemon when something changes
+	wtch.Notify(daem)
+
+	// start watching for changes
+	go wtch.Watch("/tmp/tvseries", true)
+
+	// TODO run every x minutes check for missing episodes
+	go daem.Diff()
+}

--- a/differ.go
+++ b/differ.go
@@ -1,0 +1,8 @@
+package minutes
+
+// Differ is used to find missing episodes
+type Differ interface {
+	// Diff returns episodes missing from the user's Library
+	// or returns ErrInternalServer
+	Diff(user, global *Show) (diff []*Episode, err error)
+}

--- a/differ_simple.go
+++ b/differ_simple.go
@@ -1,0 +1,10 @@
+package minutes
+
+// SimpleDiff is used to find missing episodes
+type SimpleDiff struct{}
+
+// Diff returns episodes missing from the user's Library
+// or returns ErrInternalServer
+func (d *SimpleDiff) Diff(user, global *Show) (diff []*Episode, err error) {
+	return []*Episode{}, nil
+}

--- a/downloader.go
+++ b/downloader.go
@@ -1,0 +1,42 @@
+package minutes
+
+import "errors"
+
+var (
+	// ErrDownloadableNotSupported is returned when the Downloader does not
+	// support a type of Downloadable that was added to it
+	ErrDownloadableNotSupported = errors.New("Downloadable not supported")
+	// ErrDownloadableNotComplete is returned when the Downloader cannot
+	// actually download a Downloadable due to missing information
+	ErrDownloadableNotComplete = errors.New("Downloadable not complete")
+)
+
+// Downloader handles downloading files, either on its own or through the use
+// of external apps and services
+type Downloader interface {
+	// Download adds a Downloadable to the list of things to download
+	// or errors with ErrDownloadableNotSupported, ErrDownloadableNotComplete,
+	// or ErrInternalServer
+	Download(Downloadable) error
+	// List returns all Downloadables
+	// or errors with ErrInternalServer
+	List() ([]Downloadable, error)
+	// Start starts a download
+	// or errors with ErrNotFound, or ErrInternalServer
+	Start(dID string) error
+	// Stop stops a download
+	// or errors with ErrNotFound, or ErrInternalServer
+	Stop(dID string) error
+	// Progress returns the Downloadable's progress (%)
+	// or errors with ErrNotFound, or ErrInternalServer
+	Progress(dID string) error
+}
+
+// Downloadable describes anything that a Downloader could download
+// Could be a Torrent, NBZ, HTTP, anything
+// The Downloader will have to cast the added Downloadables to get any data
+// it requires to actually download it
+type Downloadable interface {
+	// GetID returns a unique identifier for this Downloadable
+	GetID() string
+}

--- a/downloader_torrents.go
+++ b/downloader_torrents.go
@@ -1,0 +1,44 @@
+package minutes
+
+// DownloadableTorrent is an implementation of the Downloadable
+type DownloadableTorrent struct{}
+
+// GetID returns the torrent's hash
+func (d *DownloadableTorrent) GetID() string {
+	return ""
+}
+
+// DownloaderTorrent is an implementation of the Downloader specifically
+// for torrent files and magnet links
+type DownloaderTorrent struct{}
+
+// Download adds a Downloadable to the list of things to download
+// or errors with ErrDownloadableNotSupported, ErrDownloadableNotComplete,
+// or ErrInternalServer
+func (d *DownloaderTorrent) Download(Downloadable) error {
+	return nil
+}
+
+// List returns all Downloadables
+// or errors with ErrInternalServer
+func (d *DownloaderTorrent) List() ([]Downloadable, error) {
+	return []Downloadable{}, nil
+}
+
+// Start starts a download
+// or errors with ErrNotFound, or ErrInternalServer
+func (d *DownloaderTorrent) Start(dID string) error {
+	return nil
+}
+
+// Stop stops a download
+// or errors with ErrNotFound, or ErrInternalServer
+func (d *DownloaderTorrent) Stop(dID string) error {
+	return nil
+}
+
+// Progress returns the Downloadable's progress (%)
+// or errors with ErrNotFound, or ErrInternalServer
+func (d *DownloaderTorrent) Progress(dID string) error {
+	return nil
+}

--- a/episodes.go
+++ b/episodes.go
@@ -1,0 +1,118 @@
+package minutes
+
+import "time"
+
+// Show struct according to the Trakt v2 API
+type Show struct {
+	ID            string `json:"id"`
+	AiredEpisodes int    `json:"aired_episodes"`
+	Airs          struct {
+		Day      string `json:"day"`
+		Time     string `json:"time"`
+		Timezone string `json:"timezone"`
+	} `json:"airs"`
+	AvailableTranslations []string `json:"available_translations"`
+	Certification         string   `json:"certification"`
+	Country               string   `json:"country"`
+	FirstAired            string   `json:"first_aired"`
+	Genres                []string `json:"genres"`
+	Homepage              string   `json:"homepage"`
+	IDs                   struct {
+		Imdb   string `json:"imdb"`
+		Slug   string `json:"slug"`
+		Tmdb   int    `json:"tmdb"`
+		Trakt  int    `json:"trakt"`
+		Tvdb   int    `json:"tvdb"`
+		Tvrage int    `json:"tvrage"`
+	} `json:"ids"`
+	Images struct {
+		Banner struct {
+			Full string `json:"full"`
+		} `json:"banner"`
+		Clearart struct {
+			Full string `json:"full"`
+		} `json:"clearart"`
+		Fanart struct {
+			Full   string `json:"full"`
+			Medium string `json:"medium"`
+			Thumb  string `json:"thumb"`
+		} `json:"fanart"`
+		Logo struct {
+			Full string `json:"full"`
+		} `json:"logo"`
+		Poster struct {
+			Full   string `json:"full"`
+			Medium string `json:"medium"`
+			Thumb  string `json:"thumb"`
+		} `json:"poster"`
+		Thumb struct {
+			Full string `json:"full"`
+		} `json:"thumb"`
+	} `json:"images"`
+	Language  string  `json:"language"`
+	Network   string  `json:"network"`
+	Overview  string  `json:"overview"`
+	Rating    float64 `json:"rating"`
+	Runtime   float64 `json:"runtime"`
+	Status    string  `json:"status"`
+	Title     string  `json:"title"`
+	Trailer   string  `json:"trailer"`
+	UpdatedAt string  `json:"updated_at"`
+	Votes     int     `json:"votes"`
+	Year      int     `json:"year"`
+}
+
+// Season struct according to the Trakt v2 API
+type Season struct {
+	ShowID       string `json:"show_id"`
+	EpisodeCount int    `json:"episode_count"`
+	IDs          struct {
+		Tmdb   int `json:"tmdb"`
+		Trakt  int `json:"trakt"`
+		Tvdb   int `json:"tvdb"`
+		Tvrage int `json:"tvrage"`
+	} `json:"ids"`
+	Images struct {
+		Poster struct {
+			Full   string `json:"full"`
+			Medium string `json:"medium"`
+			Thumb  string `json:"thumb"`
+		} `json:"poster"`
+		Thumb struct {
+			Full string `json:"full"`
+		} `json:"thumb"`
+	} `json:"images"`
+	Number   int     `json:"number"`
+	Overview string  `json:"overview"`
+	Rating   float64 `json:"rating"`
+	Votes    int     `json:"votes"`
+}
+
+// Episode struct according to the Trakt v2 API
+type Episode struct {
+	ShowID                string     `json:"show_id"`
+	SeasonID              string     `json:"season_id"`
+	AvailableTranslations []string   `json:"available_translations"`
+	FirstAired            *time.Time `json:"first_aired"`
+	IDs                   struct {
+		Imdb   string `json:"imdb"`
+		Tmdb   int    `json:"tmdb"`
+		Trakt  int    `json:"trakt"`
+		Tvdb   int    `json:"tvdb"`
+		Tvrage int    `json:"tvrage"`
+	} `json:"ids"`
+	Images struct {
+		Screenshot struct {
+			Full   string `json:"full"`
+			Medium string `json:"medium"`
+			Thumb  string `json:"thumb"`
+		} `json:"screenshot"`
+	} `json:"images"`
+	Number    int     `json:"number"`
+	Overview  string  `json:"overview"`
+	Rating    float64 `json:"rating"`
+	Season    int     `json:"season"`
+	Title     string  `json:"title"`
+	UpdatedAt string  `json:"updated_at"`
+	Votes     int     `json:"votes"`
+}

--- a/finder.go
+++ b/finder.go
@@ -1,0 +1,8 @@
+package minutes
+
+// Finder is responsible for finding Downloadables, caching is also left
+// to the implementation and is optional
+type Finder interface {
+	// Find returns a list of Downloadables for a given Episode
+	Find(episode *Episode) ([]Downloadable, error)
+}

--- a/finder_torrents.go
+++ b/finder_torrents.go
@@ -1,0 +1,10 @@
+package minutes
+
+// TorrentFinder is an implementation of Finder that can search for torrent
+// files and magnet links
+type TorrentFinder struct{}
+
+// Find Downloadable Torrents for a given Episode
+func (f *TorrentFinder) Find(episode *Episode) ([]Downloadable, error) {
+	return []Downloadable{}, nil
+}

--- a/library.go
+++ b/library.go
@@ -1,0 +1,67 @@
+package minutes
+
+import "errors"
+
+var (
+	// ErrNotFound is returned when a single resource was requested
+	// but was not found
+	ErrNotFound = errors.New("Not found")
+	// ErrInternalServer is returned when the request failed with
+	// anything that was out of the requester's control
+	ErrInternalServer = errors.New("Internal server error")
+	// ErrMissingShow is returned when trying to request, add, or modify
+	// a resource that is related to a Show, but the Show does not exist
+	ErrMissingShow = errors.New("Show does not exist")
+	// ErrMissingSeason is returned when trying to request, add, or modify
+	// a resource that is related to a Season, but the Season does not exist
+	ErrMissingSeason = errors.New("Season does not exist")
+	// ErrNotImplemented is returned when trying to add a new resource on a
+	// read-only Library
+	ErrNotImplemented = errors.New("Not implemented")
+)
+
+// Library holds all available information about shows, seasons, and episodes
+// By default uses IMDB IDs as unique identifier, a string
+// There should be at least two implementation of this interface
+// * A global library that should contain all known shows, seasons, and episodes
+// * A user-specific library that holds the shows, seasons, and episodes of a
+//   single user
+type Library interface {
+	// UpsertShow adds or updates a show
+	// or error with ErrNotImplemented, or ErrInternalServer
+	UpsertShow(show *Show) error
+	// UpsertSeason adds or updates a season
+	// or errors with ErrNotImplemented, or ErrInternalServer, or ErrMissingShow
+	UpsertSeason(season *Season) error
+	// UpsertEpisode adds or updates a episode
+	// or errors with ErrNotImplemented, or ErrInternalServer, ErrMissingShow
+	// or ErrMissingSeason
+	UpsertEpisode(episode *Episode) error
+	// GetShow returns a Show
+	// or errors with ErrNotFound, or ErrInternalServer
+	GetShow(showID string) (*Show, error)
+	// GetShows returns all Shows
+	// or errors with ErrNotImplemented, or ErrInternalServer
+	GetShows() ([]*Show, error)
+	// GetSeason returns a Season
+	// or errors with ErrNotFound, or ErrInternalServer
+	GetSeason(seasonID string) (*Season, error)
+	// GetSeasonByNumber returns a Season given a Show's ID and a Season number
+	// or errors with ErrNotFound, ErrMissingShow, or ErrInternalServer
+	GetSeasonByNumber(showID string, seasonNumber int) (*Season, error)
+	// GetEpisode returns an Episode
+	// or errors with ErrNotFound, or ErrInternalServer
+	GetEpisode(episodeID string) (*Episode, error)
+	// GetEpisodeByNumber returns an Episode  given a Show's ID a Season number
+	// and Episode's number
+	// or errors with ErrNotFound, ErrMissingShow, or ErrInternalServer
+	GetEpisodeByNumber(showID string, seasonNumber, episodeNumber int) (*Episode, error)
+	// QueryShowsByTitle returns all Shows that match a partial title ordered
+	// by their probability
+	// or errors with ErrInternalServer
+	QueryShowsByTitle(title string) ([]*Show, error)
+	// QueryEpisodesByFile returns all episodes that match a filename or full
+	// path, ordered by their probability
+	// or errors with ErrInternalServer
+	QueryEpisodesByFile(filename string) ([]*Episode, error)
+}

--- a/library.go
+++ b/library.go
@@ -60,8 +60,4 @@ type Library interface {
 	// by their probability
 	// or errors with ErrInternalServer
 	QueryShowsByTitle(title string) ([]*Show, error)
-	// QueryEpisodesByFile returns all episodes that match a filename or full
-	// path, ordered by their probability
-	// or errors with ErrInternalServer
-	QueryEpisodesByFile(filename string) ([]*Episode, error)
 }

--- a/library_trakt.go
+++ b/library_trakt.go
@@ -1,0 +1,80 @@
+package minutes
+
+import trakt "github.com/42minutes/go-trakt"
+
+// TraktLibrary is a read-only Trakt.tv library
+type TraktLibrary struct {
+	client *trakt.Client
+}
+
+// NewTraktLibrary returns a TraktLibrary
+func NewTraktLibrary(client *trakt.Client) *TraktLibrary {
+	return &TraktLibrary{
+		client: client,
+	}
+}
+
+// UpsertShow returns ErrNotImplemented
+func (l *TraktLibrary) UpsertShow(show *Show) error {
+	return ErrNotImplemented
+}
+
+// UpsertSeason returns ErrNotImplemented
+func (l *TraktLibrary) UpsertSeason(season *Season) error {
+	return ErrNotImplemented
+}
+
+// UpsertEpisode returns ErrNotImplemented
+func (l *TraktLibrary) UpsertEpisode(episode *Episode) error {
+	return ErrNotImplemented
+}
+
+// GetShow returns a Show
+// or errors with ErrNotFound, or ErrInternalServer
+func (l *TraktLibrary) GetShow(showID string) (*Show, error) {
+	return nil, nil
+}
+
+// GetShows returns ErrNotImplemented
+func (l *TraktLibrary) GetShows() ([]*Show, error) {
+	return nil, ErrNotImplemented
+}
+
+// GetSeason returns a Season
+// or errors with ErrNotFound, or ErrInternalServer
+func (l *TraktLibrary) GetSeason(seasonID string) (*Season, error) {
+	return nil, nil
+}
+
+// GetSeasonByNumber returns a Season given a Show's ID and a Season number
+// or errors with ErrNotFound, ErrMissingShow, or ErrInternalServer
+func (l *TraktLibrary) GetSeasonByNumber(showID string, seasonNumber int) (*Season, error) {
+	return nil, nil
+}
+
+// GetEpisode returns an Episode
+// or errors with ErrNotFound, or ErrInternalServer
+func (l *TraktLibrary) GetEpisode(episodeID string) (*Episode, error) {
+	return nil, nil
+}
+
+// GetEpisodeByNumber returns an Episode  given a Show's ID a Season number
+// and Episode's number
+// or errors with ErrNotFound, ErrMissingShow, or ErrInternalServer
+func (l *TraktLibrary) GetEpisodeByNumber(showID string, seasonNumber, episodeNumber int) (*Episode, error) {
+	return nil, nil
+}
+
+// QueryShowsByTitle returns all Shows that match a partial title ordered
+// by their probability
+// or errors with ErrInternalServer
+func (l *TraktLibrary) QueryShowsByTitle(title string) ([]*Show, error) {
+	return []*Show{}, nil
+}
+
+// QueryEpisodesByFile returns all episodes that match a filename or full
+// path, ordered by their probability
+// or errors with ErrInternalServer
+func (l *TraktLibrary) QueryEpisodesByFile(filename string) ([]*Episode, error) {
+	return []*Episode{}, nil
+}

--- a/library_trakt.go
+++ b/library_trakt.go
@@ -71,10 +71,3 @@ func (l *TraktLibrary) GetEpisodeByNumber(showID string, seasonNumber, episodeNu
 func (l *TraktLibrary) QueryShowsByTitle(title string) ([]*Show, error) {
 	return []*Show{}, nil
 }
-
-// QueryEpisodesByFile returns all episodes that match a filename or full
-// path, ordered by their probability
-// or errors with ErrInternalServer
-func (l *TraktLibrary) QueryEpisodesByFile(filename string) ([]*Episode, error) {
-	return []*Episode{}, nil
-}

--- a/library_user.go
+++ b/library_user.go
@@ -1,0 +1,87 @@
+package minutes
+
+import "github.com/dancannon/gorethink"
+
+// UserLibrary is a read-write user-specific library
+type UserLibrary struct {
+	rethinkdb *gorethink.Session
+	userID    string
+}
+
+// NewUserLibrary returns a UserLibrary
+func NewUserLibrary(rethinkdb *gorethink.Session, userID string) *UserLibrary {
+	return &UserLibrary{
+		rethinkdb: rethinkdb,
+		userID:    userID,
+	}
+}
+
+// UpsertShow adds or updates a show
+// or error with ErrNotImplemented, or ErrInternalServer
+func (l *UserLibrary) UpsertShow(show *Show) error {
+	return nil
+}
+
+// UpsertSeason adds or updates a season
+// or errors with ErrNotImplemented, or ErrInternalServer, or ErrMissingShow
+func (l *UserLibrary) UpsertSeason(season *Season) error {
+	return nil
+}
+
+// UpsertEpisode adds or updates a episode
+// or errors with ErrNotImplemented, or ErrInternalServer, ErrMissingShow
+// or ErrMissingSeason
+func (l *UserLibrary) UpsertEpisode(episode *Episode) error {
+	return nil
+}
+
+// GetShow returns a Show
+// or errors with ErrNotFound, or ErrInternalServer
+func (l *UserLibrary) GetShow(showID string) (*Show, error) {
+	return nil, nil
+}
+
+// GetShows returns all Shows
+// or errors with ErrInternalServer
+func (l *UserLibrary) GetShows() ([]*Show, error) {
+	return []*Show{}, nil
+}
+
+// GetSeason returns a Season
+// or errors with ErrNotFound, or ErrInternalServer
+func (l *UserLibrary) GetSeason(seasonID string) (*Season, error) {
+	return nil, nil
+}
+
+// GetSeasonByNumber returns a Season given a Show's ID and a Season number
+// or errors with ErrNotFound, ErrMissingShow, or ErrInternalServer
+func (l *UserLibrary) GetSeasonByNumber(showID string, seasonNumber int) (*Season, error) {
+	return nil, nil
+}
+
+// GetEpisode returns an Episode
+// or errors with ErrNotFound, or ErrInternalServer
+func (l *UserLibrary) GetEpisode(episodeID string) (*Episode, error) {
+	return nil, nil
+}
+
+// GetEpisodeByNumber returns an Episode  given a Show's ID a Season number
+// and Episode's number
+// or errors with ErrNotFound, ErrMissingShow, or ErrInternalServer
+func (l *UserLibrary) GetEpisodeByNumber(showID string, seasonNumber, episodeNumber int) (*Episode, error) {
+	return nil, nil
+}
+
+// QueryShowsByTitle returns all Shows that match a partial title ordered
+// by their probability
+// or errors with ErrInternalServer
+func (l *UserLibrary) QueryShowsByTitle(title string) ([]*Show, error) {
+	return []*Show{}, nil
+}
+
+// QueryEpisodesByFile returns all episodes that match a filename or full
+// path, ordered by their probability
+// or errors with ErrInternalServer
+func (l *UserLibrary) QueryEpisodesByFile(filename string) ([]*Episode, error) {
+	return []*Episode{}, nil
+}

--- a/library_user.go
+++ b/library_user.go
@@ -78,10 +78,3 @@ func (l *UserLibrary) GetEpisodeByNumber(showID string, seasonNumber, episodeNum
 func (l *UserLibrary) QueryShowsByTitle(title string) ([]*Show, error) {
 	return []*Show{}, nil
 }
-
-// QueryEpisodesByFile returns all episodes that match a filename or full
-// path, ordered by their probability
-// or errors with ErrInternalServer
-func (l *UserLibrary) QueryEpisodesByFile(filename string) ([]*Episode, error) {
-	return []*Episode{}, nil
-}

--- a/matcher.go
+++ b/matcher.go
@@ -1,0 +1,9 @@
+package minutes
+
+// Matcher tries to match a filename with an episode
+type Matcher interface {
+	// Match returns all episodes that match a filename or full path,
+	// ordered by their probability
+	// or errors with ErrInternalServer
+	Match(filename string) ([]*Episode, error)
+}

--- a/matcher_simple.go
+++ b/matcher_simple.go
@@ -1,0 +1,21 @@
+package minutes
+
+// SimpleMatch uses regular expressions to match against a show, season,
+// and episode
+type SimpleMatch struct {
+	globalLibrary Library
+}
+
+// NewSimpleMatch returns a SimpleMatch
+func NewSimpleMatch(glib Library) (*SimpleMatch, error) {
+	return &SimpleMatch{
+		globalLibrary: glib,
+	}, nil
+}
+
+// Match returns all episodes that match a filename or full path,
+// ordered by their probability
+// or errors with ErrInternalServer
+func (m *SimpleMatch) Match(filename string) ([]*Episode, error) {
+	return []*Episode{}, nil
+}

--- a/watcher.go
+++ b/watcher.go
@@ -1,0 +1,30 @@
+package minutes
+
+// NotificationType for the types of Watcher notifications
+type NotificationType int
+
+const (
+	// NotificationFileCreated - file created
+	NotificationFileCreated NotificationType = iota
+	// NotificationFileUpdated - file updated (optional)
+	NotificationFileUpdated
+	// NotificationFileMoved - file moved (optiona)
+	NotificationFileMoved
+	// NotificationFileRemoved - file removed
+	NotificationFileRemoved
+)
+
+// Watcher watches a directory or api notifies Notifiees for file changes
+type Watcher interface {
+	// Watch starts watching a directory or api
+	// or errors with ErrInternalServer
+	Watch(path string, recursive bool) error
+	// Notify adds Notifiees that want to be notified about file changes
+	Notify(WatcherNotifiee)
+}
+
+// WatcherNotifiee is anything that wants to be notified about file changes
+type WatcherNotifiee interface {
+	// HandleWatcherNotification handles Watcher notifications
+	HandleWatcherNotification(notifType NotificationType, path string)
+}

--- a/watcher_file.go
+++ b/watcher_file.go
@@ -1,0 +1,12 @@
+package minutes
+
+// FileWatcher watches a directory and notifies Notifiees for file changes
+type FileWatcher struct{}
+
+// Watch starts watching a folder
+func (fw *FileWatcher) Watch(path string, recursive bool) error {
+	return nil
+}
+
+// Notify registers a Notifiee to be notified about file updates
+func (fw *FileWatcher) Notify(WatcherNotifiee) {}


### PR DESCRIPTION
### Requirements

The standalone daemon...
- should assume there is only one single user
- must be able to recursively scan a folder and match them with episodes
- must persist the user's shows, seasons, and episodes in theirlibrary
- must be able to go through the user's shows and find if there are missing (or new) episodes
- must be able to find download sources for the missing episodes
- must be able to download the missing episodes  
### Changelog
- Adds standalone daemon cmd outline
- Adds structs for `Show`, `Season`, `Episode`
- Adds interface for `Differ` and concrete outline for `SimpleDiff`
- Adds interface for `Downloader` and concrete outline for `TorrentDownloader`
- Adds interface for `Finder` and concrete outline for `FinderTorrent`
- Adds interface for `Library` and concrete outline for `TraktLibrary` and `UserLibrary`
- Adds interface for `Watcher` and concrete outline for `FileWatcher`
### To do
- Refactor interface and concrete implementations naming
- ~~Add an HTTP interface to manage user library in standalone daemon~~
- ~~Add a way to find newly released episodes and download them~~
- ~~Add an RSS exporter instead of downloading episodes directly~~

_Edit: On second thought, the last three to-do items are not really required for a proof of concept so we can skip them for now._
