### PR TITLE
Add rethinkdb persisted user library

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+rethinkdb:
+    image: rethinkdb
+    ports:
+        - "8080:8080"
+        - "28015:28015"
+        - "29015:29015"

--- a/episodes.go
+++ b/episodes.go
@@ -4,115 +4,117 @@ import "time"
 
 // Show struct according to the Trakt v2 API
 type Show struct {
-	ID            string `json:"id"`
-	AiredEpisodes int    `json:"aired_episodes"`
+	ID            string `json:"id" gorethink:"id"`
+	AiredEpisodes int    `json:"aired_episodes" gorethink:"aired_episodes"`
 	Airs          struct {
-		Day      string `json:"day"`
-		Time     string `json:"time"`
-		Timezone string `json:"timezone"`
-	} `json:"airs"`
-	AvailableTranslations []string `json:"available_translations"`
-	Certification         string   `json:"certification"`
-	Country               string   `json:"country"`
-	FirstAired            string   `json:"first_aired"`
-	Genres                []string `json:"genres"`
-	Homepage              string   `json:"homepage"`
+		Day      string `json:"day" gorethink:"day,omitempty"`
+		Time     string `json:"time" gorethink:"time,omitempty"`
+		Timezone string `json:"timezone" gorethink:"timezone,omitempty"`
+	} `json:"airs" gorethink:"airs,omitempty"`
+	AvailableTranslations []string `json:"available_translations" gorethink:"available_translations,omitempty"`
+	Certification         string   `json:"certification" gorethink:"certification,omitempty"`
+	Country               string   `json:"country" gorethink:"country,omitempty"`
+	FirstAired            string   `json:"first_aired" gorethink:"first_aired,omitempty"`
+	Genres                []string `json:"genres" gorethink:"genres,omitempty"`
+	Homepage              string   `json:"homepage" gorethink:"homepage,omitempty"`
 	IDs                   struct {
-		Imdb   string `json:"imdb"`
-		Slug   string `json:"slug"`
-		Tmdb   int    `json:"tmdb"`
-		Trakt  int    `json:"trakt"`
-		Tvdb   int    `json:"tvdb"`
-		Tvrage int    `json:"tvrage"`
-	} `json:"ids"`
+		Imdb   string `json:"imdb" gorethink:"imdb,omitempty"`
+		Slug   string `json:"slug" gorethink:"slug,omitempty"`
+		Tmdb   int    `json:"tmdb" gorethink:"tmdb,omitempty"`
+		Trakt  int    `json:"trakt" gorethink:"trakt,omitempty"`
+		Tvdb   int    `json:"tvdb" gorethink:"tvdb,omitempty"`
+		Tvrage int    `json:"tvrage" gorethink:"tvrage,omitempty"`
+	} `json:"ids" gorethink:"ids"`
 	Images struct {
 		Banner struct {
-			Full string `json:"full"`
-		} `json:"banner"`
+			Full string `json:"full" gorethink:"full,omitempty"`
+		} `json:"banner" gorethink:"banner,omitempty"`
 		Clearart struct {
-			Full string `json:"full"`
-		} `json:"clearart"`
+			Full string `json:"full" gorethink:"full,omitempty"`
+		} `json:"clearart" gorethink:"full,omitempty"`
 		Fanart struct {
-			Full   string `json:"full"`
-			Medium string `json:"medium"`
-			Thumb  string `json:"thumb"`
-		} `json:"fanart"`
+			Full   string `json:"full" gorethink:"full,omitempty"`
+			Medium string `json:"medium" gorethink:"medium,omitempty"`
+			Thumb  string `json:"thumb" gorethink:"thumb,omitempty"`
+		} `json:"fanart" gorethink:"fanart,omitempty"`
 		Logo struct {
-			Full string `json:"full"`
-		} `json:"logo"`
+			Full string `json:"full" gorethink:"full,omitempty"`
+		} `json:"logo" gorethink:"logo,omitempty"`
 		Poster struct {
-			Full   string `json:"full"`
-			Medium string `json:"medium"`
-			Thumb  string `json:"thumb"`
-		} `json:"poster"`
+			Full   string `json:"full" gorethink:"full,omitempty"`
+			Medium string `json:"medium" gorethink:"medium,omitempty"`
+			Thumb  string `json:"thumb" gorethink:"thumb,omitempty"`
+		} `json:"poster" gorethink:"poster,omitempty"`
 		Thumb struct {
-			Full string `json:"full"`
-		} `json:"thumb"`
-	} `json:"images"`
-	Language  string  `json:"language"`
-	Network   string  `json:"network"`
-	Overview  string  `json:"overview"`
-	Rating    float64 `json:"rating"`
-	Runtime   float64 `json:"runtime"`
-	Status    string  `json:"status"`
-	Title     string  `json:"title"`
-	Trailer   string  `json:"trailer"`
-	UpdatedAt string  `json:"updated_at"`
-	Votes     int     `json:"votes"`
-	Year      int     `json:"year"`
+			Full string `json:"full" gorethink:"full,omitempty"`
+		} `json:"thumb" gorethink:"thumb,omitempty"`
+	} `json:"images" gorethink:"images,omitempty"`
+	Language  string  `json:"language" gorethink:"language,omitempty"`
+	Network   string  `json:"network" gorethink:"network,omitempty"`
+	Overview  string  `json:"overview" gorethink:"overview,omitempty"`
+	Rating    float64 `json:"rating" gorethink:"rating,omitempty"`
+	Runtime   float64 `json:"runtime" gorethink:"runtime,omitempty"`
+	Status    string  `json:"status" gorethink:"status,omitempty"`
+	Title     string  `json:"title" gorethink:"title,omitempty"`
+	Trailer   string  `json:"trailer" gorethink:"trailer,omitempty"`
+	UpdatedAt string  `json:"updated_at" gorethink:"updated_at,omitempty"`
+	Votes     int     `json:"votes" gorethink:"votes,omitempty"`
+	Year      int     `json:"year" gorethink:"year,omitempty"`
 }
 
 // Season struct according to the Trakt v2 API
 type Season struct {
-	ShowID       string `json:"show_id"`
-	EpisodeCount int    `json:"episode_count"`
+	ID           string `json:"id" gorethink:"id"`
+	ShowID       string `json:"show_id" gorethink:"show_id"`
+	EpisodeCount int    `json:"episode_count" gorethink:"episode_count"`
 	IDs          struct {
-		Tmdb   int `json:"tmdb"`
-		Trakt  int `json:"trakt"`
-		Tvdb   int `json:"tvdb"`
-		Tvrage int `json:"tvrage"`
-	} `json:"ids"`
+		Tmdb   int `json:"tmdb" gorethink:"tmdb,omitempty"`
+		Trakt  int `json:"trakt" gorethink:"trakt,omitempty"`
+		Tvdb   int `json:"tvdb" gorethink:"tvdb,omitempty"`
+		Tvrage int `json:"tvrage" gorethink:"tvrage,omitempty"`
+	} `json:"ids" gorethink:"ids"`
 	Images struct {
 		Poster struct {
-			Full   string `json:"full"`
-			Medium string `json:"medium"`
-			Thumb  string `json:"thumb"`
-		} `json:"poster"`
+			Full   string `json:"full" gorethink:"full,omitempty"`
+			Medium string `json:"medium" gorethink:"medium,omitempty"`
+			Thumb  string `json:"thumb" gorethink:"thumb,omitempty"`
+		} `json:"poster" gorethink:"poster,omitempty"`
 		Thumb struct {
-			Full string `json:"full"`
-		} `json:"thumb"`
-	} `json:"images"`
-	Number   int     `json:"number"`
-	Overview string  `json:"overview"`
-	Rating   float64 `json:"rating"`
-	Votes    int     `json:"votes"`
+			Full string `json:"full" gorethink:"full,omitempty"`
+		} `json:"thumb" gorethink:"thumb,omitempty"`
+	} `json:"images" gorethink:"images,omitempty"`
+	Number   int     `json:"number" gorethink:"number,omitempty"`
+	Overview string  `json:"overview" gorethink:"overview,omitempty"`
+	Rating   float64 `json:"rating" gorethink:"rating,omitempty"`
+	Votes    int     `json:"votes" gorethink:"votes,omitempty"`
 }
 
 // Episode struct according to the Trakt v2 API
 type Episode struct {
-	ShowID                string     `json:"show_id"`
-	SeasonID              string     `json:"season_id"`
-	AvailableTranslations []string   `json:"available_translations"`
-	FirstAired            *time.Time `json:"first_aired"`
+	ID                    string     `json:"id" gorethink:"id"`
+	ShowID                string     `json:"show_id" gorethink:"show_id"`
+	SeasonID              string     `json:"season_id" gorethink:"season_id,omitempty"`
+	AvailableTranslations []string   `json:"available_translations" gorethink:"available_translations,omitempty"`
+	FirstAired            *time.Time `json:"first_aired" gorethink:"first_aired,omitempty"`
 	IDs                   struct {
-		Imdb   string `json:"imdb"`
-		Tmdb   int    `json:"tmdb"`
-		Trakt  int    `json:"trakt"`
-		Tvdb   int    `json:"tvdb"`
-		Tvrage int    `json:"tvrage"`
-	} `json:"ids"`
+		Imdb   string `json:"imdb" gorethink:"imdb,omitempty"`
+		Tmdb   int    `json:"tmdb" gorethink:"tmdb,omitempty"`
+		Trakt  int    `json:"trakt" gorethink:"trakt,omitempty"`
+		Tvdb   int    `json:"tvdb" gorethink:"tvdb,omitempty"`
+		Tvrage int    `json:"tvrage" gorethink:"tvrage,omitempty"`
+	} `json:"ids" gorethink:"ids"`
 	Images struct {
 		Screenshot struct {
-			Full   string `json:"full"`
-			Medium string `json:"medium"`
-			Thumb  string `json:"thumb"`
-		} `json:"screenshot"`
-	} `json:"images"`
-	Number    int     `json:"number"`
-	Overview  string  `json:"overview"`
-	Rating    float64 `json:"rating"`
-	Season    int     `json:"season"`
-	Title     string  `json:"title"`
-	UpdatedAt string  `json:"updated_at"`
-	Votes     int     `json:"votes"`
+			Full   string `json:"full" gorethink:"full,omitempty"`
+			Medium string `json:"medium" gorethink:"medium,omitempty"`
+			Thumb  string `json:"thumb" gorethink:"thumb,omitempty"`
+		} `json:"screenshot" gorethink:"screenshot,omitempty"`
+	} `json:"images" gorethink:"images,omitempty"`
+	Number    int     `json:"number" gorethink:"number,omitempty"`
+	Overview  string  `json:"overview" gorethink:"overview,omitempty"`
+	Rating    float64 `json:"rating" gorethink:"rating,omitempty"`
+	Season    int     `json:"season" gorethink:"season,omitempty"`
+	Title     string  `json:"title" gorethink:"title,omitempty"`
+	UpdatedAt string  `json:"updated_at" gorethink:"updated_at,omitempty"`
+	Votes     int     `json:"votes" gorethink:"votes,omitempty"`
 }

--- a/episodes.reql
+++ b/episodes.reql
@@ -1,0 +1,7 @@
+r.dbCreate('library');
+r.db('library').tableCreate('shows');
+r.db('library').tableCreate('seasons');
+r.db('library').table('seasons').indexCreate('show_id');
+r.db('library').tableCreate('episodes');
+r.db('library').table('episodes').indexCreate('show_id');
+r.db('library').table('episodes').indexCreate('season_id');

--- a/library_user.go
+++ b/library_user.go
@@ -1,15 +1,25 @@
 package minutes
 
-import "github.com/dancannon/gorethink"
+import (
+	"fmt"
+
+	rethink "github.com/dancannon/gorethink"
+)
+
+const (
+	tableShows    = "shows"
+	tableSeasons  = "seasons"
+	tableEpisodes = "episodes"
+)
 
 // UserLibrary is a read-write user-specific library
 type UserLibrary struct {
-	rethinkdb *gorethink.Session
+	rethinkdb *rethink.Session
 	userID    string
 }
 
 // NewUserLibrary returns a UserLibrary
-func NewUserLibrary(rethinkdb *gorethink.Session, userID string) *UserLibrary {
+func NewUserLibrary(rethinkdb *rethink.Session, userID string) *UserLibrary {
 	return &UserLibrary{
 		rethinkdb: rethinkdb,
 		userID:    userID,
@@ -19,62 +29,213 @@ func NewUserLibrary(rethinkdb *gorethink.Session, userID string) *UserLibrary {
 // UpsertShow adds or updates a show
 // or error with ErrNotImplemented, or ErrInternalServer
 func (l *UserLibrary) UpsertShow(show *Show) error {
-	return nil
+	return l.upsert(tableShows, show)
 }
 
 // UpsertSeason adds or updates a season
 // or errors with ErrNotImplemented, or ErrInternalServer, or ErrMissingShow
 func (l *UserLibrary) UpsertSeason(season *Season) error {
-	return nil
+	return l.upsert(tableSeasons, season)
 }
 
 // UpsertEpisode adds or updates a episode
 // or errors with ErrNotImplemented, or ErrInternalServer, ErrMissingShow
 // or ErrMissingSeason
 func (l *UserLibrary) UpsertEpisode(episode *Episode) error {
-	return nil
+	return l.upsert(tableEpisodes, episode)
 }
 
 // GetShow returns a Show
 // or errors with ErrNotFound, or ErrInternalServer
-func (l *UserLibrary) GetShow(showID string) (*Show, error) {
-	return nil, nil
+func (l *UserLibrary) GetShow(id string) (*Show, error) {
+	sh := &Show{}
+	err := l.get(tableShows, id, sh)
+	return sh, err
 }
 
 // GetShows returns all Shows
 // or errors with ErrInternalServer
 func (l *UserLibrary) GetShows() ([]*Show, error) {
-	return []*Show{}, nil
+	res, err := rethink.Table(tableShows).Run(l.rethinkdb)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	defer res.Close()
+	shs := []*Show{}
+	if res.IsNil() {
+		return shs, nil
+	}
+	err = res.All(&shs)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	return shs, nil
 }
 
 // GetSeason returns a Season
 // or errors with ErrNotFound, or ErrInternalServer
-func (l *UserLibrary) GetSeason(seasonID string) (*Season, error) {
-	return nil, nil
+func (l *UserLibrary) GetSeason(id string) (*Season, error) {
+	se := &Season{}
+	err := l.get(tableSeasons, id, se)
+	return se, err
+}
+
+// GetSeasonsByShow returns all Seasons for a show
+// or errors with ErrNotFound, or ErrInternalServer
+func (l *UserLibrary) GetSeasonsByShow(sid string) ([]*Season, error) {
+	qr := rethink.Table(tableSeasons).GetAllByIndex("show_id", sid)
+	res, err := qr.Run(l.rethinkdb)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	defer res.Close()
+	ses := []*Season{}
+	if res.IsNil() {
+		return ses, nil
+	}
+	err = res.All(&ses)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	return ses, nil
 }
 
 // GetSeasonByNumber returns a Season given a Show's ID and a Season number
 // or errors with ErrNotFound, ErrMissingShow, or ErrInternalServer
-func (l *UserLibrary) GetSeasonByNumber(showID string, seasonNumber int) (*Season, error) {
-	return nil, nil
+func (l *UserLibrary) GetSeasonByNumber(sid string, sn int) (*Season, error) {
+	qr := rethink.Table(tableSeasons).GetAllByIndex("show_id", sid)
+	qr = qr.Filter(map[string]interface{}{"number": sn})
+	res, err := qr.Run(l.rethinkdb)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	defer res.Close()
+	if res.IsNil() {
+		return nil, ErrNotFound
+	}
+	se := &Season{}
+	if err := res.One(se); err != nil {
+		return nil, ErrInternalServer
+	}
+	return se, nil
 }
 
 // GetEpisode returns an Episode
 // or errors with ErrNotFound, or ErrInternalServer
-func (l *UserLibrary) GetEpisode(episodeID string) (*Episode, error) {
-	return nil, nil
+func (l *UserLibrary) GetEpisode(id string) (*Episode, error) {
+	ep := &Episode{}
+	err := l.get(tableEpisodes, id, ep)
+	return ep, err
+}
+
+// GetEpisodesBySeason returns all Episodes for a Season
+// or errors with ErrNotFound, or ErrInternalServer
+func (l *UserLibrary) GetEpisodesBySeason(sid string) ([]*Episode, error) {
+	qr := rethink.Table(tableEpisodes).GetAllByIndex("season_id", sid)
+	res, err := qr.Run(l.rethinkdb)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	defer res.Close()
+	eps := []*Episode{}
+	if res.IsNil() {
+		return eps, nil
+	}
+	err = res.All(&eps)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	return eps, nil
+}
+
+// GetEpisodesBySeasonNumber returns all Shows for a show and season number
+// or errors with ErrNotFound, or ErrInternalServer
+func (l *UserLibrary) GetEpisodesBySeasonNumber(sid string, sn int) ([]*Episode, error) {
+	qr := rethink.Table(tableEpisodes).GetAllByIndex("show_id", sid)
+	qr = qr.Filter(map[string]interface{}{"season": sn})
+	res, err := qr.Run(l.rethinkdb)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	defer res.Close()
+	eps := []*Episode{}
+	if res.IsNil() {
+		return eps, nil
+	}
+	err = res.All(&eps)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	return eps, nil
 }
 
 // GetEpisodeByNumber returns an Episode  given a Show's ID a Season number
 // and Episode's number
 // or errors with ErrNotFound, ErrMissingShow, or ErrInternalServer
-func (l *UserLibrary) GetEpisodeByNumber(showID string, seasonNumber, episodeNumber int) (*Episode, error) {
-	return nil, nil
+func (l *UserLibrary) GetEpisodeByNumber(sid string, sn, en int) (*Episode, error) {
+	qr := rethink.Table(tableEpisodes).GetAllByIndex("show_id", sid)
+	qr = qr.Filter(map[string]interface{}{"season": sn, "number": en})
+	res, err := qr.Run(l.rethinkdb)
+	if err != nil {
+		fmt.Println(err)
+		return nil, ErrInternalServer
+	}
+	defer res.Close()
+	if res.IsNil() {
+		return nil, ErrNotFound
+	}
+	ep := &Episode{}
+	if err := res.One(ep); err != nil {
+		return nil, ErrInternalServer
+	}
+	return ep, nil
 }
 
 // QueryShowsByTitle returns all Shows that match a partial title ordered
 // by their probability
 // or errors with ErrInternalServer
 func (l *UserLibrary) QueryShowsByTitle(title string) ([]*Show, error) {
-	return []*Show{}, nil
+	qr := rethink.Table(tableShows)
+	qr = qr.Filter(rethink.Row.Field("title").Match(title))
+	res, err := qr.Run(l.rethinkdb)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	defer res.Close()
+	shs := []*Show{}
+	if res.IsNil() {
+		return shs, nil
+	}
+	err = res.All(&shs)
+	if err != nil {
+		return nil, ErrInternalServer
+	}
+	return shs, nil
+}
+
+func (l *UserLibrary) upsert(tbl string, doc interface{}) error {
+	insertOpts := rethink.InsertOpts{
+		Conflict: "update",
+	}
+	qr := rethink.Table(tbl).Insert(doc, insertOpts)
+	if _, err := qr.RunWrite(l.rethinkdb); err != nil {
+		// TODO(geoah) log error
+		return ErrInternalServer
+	}
+	return nil
+}
+
+func (l *UserLibrary) get(tbl, id string, doc interface{}) error {
+	res, err := rethink.Table(tbl).Get(id).Run(l.rethinkdb)
+	if err != nil {
+		return ErrInternalServer
+	}
+	defer res.Close()
+	if res.IsNil() {
+		return ErrNotFound
+	}
+	if err := res.One(doc); err != nil {
+		return ErrInternalServer
+	}
+	return nil
 }

--- a/library_user_test.go
+++ b/library_user_test.go
@@ -1,0 +1,388 @@
+package minutes
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	rethink "github.com/dancannon/gorethink"
+	suite "github.com/stretchr/testify/suite"
+)
+
+const (
+	database = "test_library"
+)
+
+var (
+	// shows
+	s1 = &Show{
+		ID:    "1",
+		Title: "first-show",
+	}
+	s2 = &Show{
+		ID:    "2",
+		Title: "second-show",
+	}
+
+	// seasons
+	s1s1 = &Season{
+		ID:       "3",
+		ShowID:   "1",
+		Number:   1,
+		Overview: "first-season",
+	}
+	s1s2 = &Season{
+		ID:       "4",
+		ShowID:   "1",
+		Number:   2,
+		Overview: "second-season",
+	}
+	s2s1 = &Season{
+		ID:       "5",
+		ShowID:   "2",
+		Number:   1,
+		Overview: "first-season",
+	}
+	s2s2 = &Season{
+		ID:       "6",
+		ShowID:   "2",
+		Number:   2,
+		Overview: "second-season",
+	}
+
+	// episodes
+	s1s1e1 = &Episode{
+		ID:     "7",
+		ShowID: "1",
+		Season: 1,
+		Number: 1,
+		Title:  "first-episode",
+	}
+	s1s1e2 = &Episode{
+		ID:     "8",
+		ShowID: "1",
+		Season: 1,
+		Number: 2,
+		Title:  "second-episode",
+	}
+	s1s1e3 = &Episode{
+		ID:     "9",
+		ShowID: "1",
+		Season: 1,
+		Number: 3,
+		Title:  "third-episode",
+	}
+	s2s2e2 = &Episode{
+		ID:     "10",
+		ShowID: "2",
+		Season: 2,
+		Number: 2,
+		Title:  "second-episode",
+	}
+)
+
+func TestUserLibrarySuite(t *testing.T) {
+	suite.Run(t, new(UserLibraryPersistenceSuite))
+}
+
+type UserLibraryPersistenceSuite struct {
+	suite.Suite
+	rethink *rethink.Session
+	library Library
+}
+
+func (s *UserLibraryPersistenceSuite) SetupSuite() {
+	host := os.Getenv("RETHINKDB_PORT_28015_TCP_ADDR")
+	if host == "" {
+		host = "localhost"
+	}
+
+	port := os.Getenv("RETHINKDB_PORT_28015_TCP_PORT")
+	if port == "" {
+		port = "28015"
+	}
+
+	re, errConnecting := rethink.Connect(rethink.ConnectOpts{
+		Address:  host + ":" + port,
+		Database: database,
+	})
+
+	if errConnecting != nil {
+		fmt.Println("Could not connect to db", errConnecting)
+	}
+
+	s.library = &UserLibrary{
+		rethinkdb: re,
+	}
+	s.rethink = re
+
+	rethink.DBDrop(database).Run(s.rethink)
+	rethink.DBCreate(database).Run(s.rethink)
+
+	rethink.DB(database).TableCreate(tableShows).Run(s.rethink)
+	rethink.DB(database).TableCreate(tableSeasons).Run(s.rethink)
+	rethink.DB(database).TableCreate(tableEpisodes).Run(s.rethink)
+
+	rethink.DB(database).Table(tableSeasons).IndexCreate("show_id").Run(s.rethink)
+	rethink.DB(database).Table(tableSeasons).IndexCreate("show_id").Run(s.rethink)
+	rethink.DB(database).Table(tableEpisodes).IndexCreate("show_id").Run(s.rethink)
+
+	rethink.DB(database).Table(tableEpisodes).IndexCreate("season_id").Run(s.rethink)
+
+	rethink.DB(database).Table(tableShows).IndexWait().Exec(s.rethink)
+	rethink.DB(database).Table(tableSeasons).IndexWait().Exec(s.rethink)
+	rethink.DB(database).Table(tableEpisodes).IndexWait().Exec(s.rethink)
+}
+
+func (s *UserLibraryPersistenceSuite) SetupTest() {
+	rethink.DB(database).Table(tableShows).Delete().RunWrite(s.rethink)
+	rethink.DB(database).Table(tableSeasons).Delete().RunWrite(s.rethink)
+	rethink.DB(database).Table(tableEpisodes).Delete().RunWrite(s.rethink)
+}
+
+func (s *UserLibraryPersistenceSuite) count(tbl string) int {
+	cursor, err := rethink.Table(tbl).Count().Run(s.rethink)
+	if err != nil {
+		s.Fail(err.Error())
+	}
+	var cnt int
+	cursor.One(&cnt)
+	cursor.Close()
+	return cnt
+}
+
+func (s *UserLibraryPersistenceSuite) addShows() {
+	err := s.library.UpsertShow(s1)
+	s.Nil(err)
+
+	err = s.library.UpsertShow(s2)
+	s.Nil(err)
+
+	s.Equal(2, s.count(tableShows))
+}
+
+func (s *UserLibraryPersistenceSuite) addSeasons() {
+	err := s.library.UpsertSeason(s1s1)
+	s.Nil(err)
+
+	err = s.library.UpsertSeason(s1s2)
+	s.Nil(err)
+
+	err = s.library.UpsertSeason(s2s1)
+	s.Nil(err)
+
+	err = s.library.UpsertSeason(s2s2)
+	s.Nil(err)
+
+	s.Equal(4, s.count(tableSeasons))
+}
+
+func (s *UserLibraryPersistenceSuite) addEpisodes() {
+	err := s.library.UpsertEpisode(s1s1e1)
+	s.Nil(err)
+
+	err = s.library.UpsertEpisode(s1s1e2)
+	s.Nil(err)
+
+	err = s.library.UpsertEpisode(s1s1e3)
+	s.Nil(err)
+
+	err = s.library.UpsertEpisode(s2s2e2)
+	s.Nil(err)
+
+	s.Equal(4, s.count(tableEpisodes))
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_UpsertShow_Success() {
+	s.addShows()
+
+	s1.Title = "show-first-updated"
+	err := s.library.UpsertShow(s1)
+	s.Nil(err)
+
+	s.Equal(2, s.count(tableShows))
+
+	sh, err := s.library.GetShow(s1.ID)
+	s.Equal(s1, sh)
+	s.Nil(err)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_UpsertSeason_Success() {
+	s.addSeasons()
+
+	s1s2.Overview = "second-season-updated"
+	err := s.library.UpsertSeason(s1s2)
+	s.Nil(err)
+
+	s.Equal(4, s.count(tableSeasons))
+
+	se, err := s.library.GetSeason(s1s2.ID)
+	s.Equal(s1s2, se)
+	s.Nil(err)
+
+	s2s2.Overview = "second-season-updated"
+	err = s.library.UpsertSeason(s2s2)
+	s.Nil(err)
+
+	s.Equal(4, s.count(tableSeasons))
+
+	se, err = s.library.GetSeason(s2s2.ID)
+	s.Equal(s2s2, se)
+	s.Nil(err)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_UpsertEpisode_Success() {
+	s.addEpisodes()
+
+	s1s1e3.Overview = "third-episode-updated"
+	err := s.library.UpsertEpisode(s1s1e3)
+	s.Nil(err)
+
+	s.Equal(4, s.count(tableEpisodes))
+
+	ep, err := s.library.GetEpisode(s1s1e3.ID)
+	s.Equal(s1s1e3, ep)
+	s.Nil(err)
+
+	s2s2e2.Overview = "second-episode-updated"
+	err = s.library.UpsertEpisode(s2s2e2)
+	s.Nil(err)
+
+	s.Equal(4, s.count(tableEpisodes))
+
+	ep, err = s.library.GetEpisode(s2s2e2.ID)
+	s.Equal(s2s2e2, ep)
+	s.Nil(err)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_GetShow_Success() {
+	s.addShows()
+
+	sh, err := s.library.GetShow(s1.ID)
+	s.Equal(s1, sh)
+	s.Nil(err)
+
+	sh, err = s.library.GetShow(s2.ID)
+	s.Equal(s2, sh)
+	s.Nil(err)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_GetSeason_Success() {
+	s.addSeasons()
+
+	se, err := s.library.GetSeason(s1s1.ID)
+	s.Equal(s1s1, se)
+	s.Nil(err)
+
+	se, err = s.library.GetSeason(s1s2.ID)
+	s.Equal(s1s2, se)
+	s.Nil(err)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_GetEpisode_Success() {
+	s.addEpisodes()
+
+	ep, err := s.library.GetEpisode(s1s1e1.ID)
+	s.Equal(s1s1e1, ep)
+	s.Nil(err)
+
+	ep, err = s.library.GetEpisode(s1s1e2.ID)
+	s.Equal(s1s1e2, ep)
+	s.Nil(err)
+
+	ep, err = s.library.GetEpisode(s1s1e3.ID)
+	s.Equal(s1s1e3, ep)
+	s.Nil(err)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_GetShows_Success() {
+	s.addShows()
+
+	shs, err := s.library.GetShows()
+	s.Equal(2, len(shs))
+	s.Nil(err)
+	s.Contains(shs, s1)
+	s.Contains(shs, s2)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_GetSeasonsByShow_Success() {
+	s.addShows()
+	s.addSeasons()
+
+	shs, err := s.library.GetSeasonsByShow(s1.ID)
+	s.Equal(2, len(shs))
+	s.Nil(err)
+	s.Contains(shs, s1s1)
+	s.Contains(shs, s1s2)
+
+	shs, err = s.library.GetSeasonsByShow(s2.ID)
+	s.Equal(2, len(shs))
+	s.Nil(err)
+	s.Contains(shs, s2s1)
+	s.Contains(shs, s2s2)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_GetSeasonByNumber_Success() {
+	s.addShows()
+	s.addSeasons()
+
+	se, err := s.library.GetSeasonByNumber(s1.ID, s1s1.Number)
+	s.Equal(s1s1.Overview, se.Overview)
+	s.Nil(err)
+
+	se, err = s.library.GetSeasonByNumber(s1.ID, s1s2.Number)
+	s.Equal(s1s2.Overview, se.Overview)
+	s.Nil(err)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_GetEpisodesBySeason_Success() {
+	// TODO(geoah) Method will most likely be removed, not worth writing tests
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_GetEpisodesBySeasonNumber_Success() {
+	s.addEpisodes()
+
+	eps, err := s.library.GetEpisodesBySeasonNumber(s1s1.ShowID, s1s1.Number)
+	s.Equal(3, len(eps))
+	s.Nil(err)
+	s.Contains(eps, s1s1e1)
+	s.Contains(eps, s1s1e2)
+	s.Contains(eps, s1s1e3)
+
+	eps, err = s.library.GetEpisodesBySeasonNumber(s2s2.ShowID, s2s2.Number)
+	s.Equal(1, len(eps))
+	s.Nil(err)
+	s.Contains(eps, s2s2e2)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_GetEpisodeByNumber_Success() {
+	s.addEpisodes()
+
+	ep, err := s.library.GetEpisodeByNumber(s1s1e1.ShowID, s1s1e1.Season, s1s1e1.Number)
+	s.Equal(s1s1e1, ep)
+	s.Nil(err)
+
+	ep, err = s.library.GetEpisodeByNumber(s2s2e2.ShowID, s2s2e2.Season, s2s2e2.Number)
+	s.Equal(s2s2e2, ep)
+	s.Nil(err)
+}
+
+func (s *UserLibraryPersistenceSuite) TestUserLibrary_QueryShowsByTitle_Success() {
+	s.addShows()
+
+	shs, err := s.library.QueryShowsByTitle("first")
+	s.Equal(1, len(shs))
+	s.Nil(err)
+	s.Contains(shs, s1)
+
+	shs, err = s.library.QueryShowsByTitle("second")
+	s.Equal(1, len(shs))
+	s.Nil(err)
+	s.Contains(shs, s2)
+
+	shs, err = s.library.QueryShowsByTitle("show")
+	s.Equal(2, len(shs))
+	s.Nil(err)
+	s.Contains(shs, s1)
+	s.Contains(shs, s2)
+}


### PR DESCRIPTION
### Changelog

Adds a rethinkdb persisted `UserLibrary` that implements `Library` and resolves #4.
Adds a docker compose for tests
### Notes

The following methods could probably be removed both from the `Library` interface and the two implementations - @superdecimal what do you think?
- `GetSeason`
- `GetEpisode`
- `GetEpisodesBySeason`
### Tests

Tests for all methods' successes are there and pass as expected.
Still need to add more tests for failures, but this should do for now.

And since we don't yet have ci...

```
✗ go test . -v
=== RUN   TestUserLibrarySuite
=== RUN   TestUserLibrary_GetEpisodeByNumber_Success
--- PASS: TestUserLibrary_GetEpisodeByNumber_Success (0.37s)
=== RUN   TestUserLibrary_GetEpisode_Success
--- PASS: TestUserLibrary_GetEpisode_Success (0.30s)
=== RUN   TestUserLibrary_GetEpisodesBySeasonNumber_Success
--- PASS: TestUserLibrary_GetEpisodesBySeasonNumber_Success (0.30s)
=== RUN   TestUserLibrary_GetEpisodesBySeason_Success
--- PASS: TestUserLibrary_GetEpisodesBySeason_Success (0.06s)
=== RUN   TestUserLibrary_GetSeasonByNumber_Success
--- PASS: TestUserLibrary_GetSeasonByNumber_Success (0.35s)
=== RUN   TestUserLibrary_GetSeason_Success
--- PASS: TestUserLibrary_GetSeason_Success (0.53s)
=== RUN   TestUserLibrary_GetSeasonsByShow_Success
--- PASS: TestUserLibrary_GetSeasonsByShow_Success (0.38s)
=== RUN   TestUserLibrary_GetShow_Success
--- PASS: TestUserLibrary_GetShow_Success (0.20s)
=== RUN   TestUserLibrary_GetShows_Success
--- PASS: TestUserLibrary_GetShows_Success (0.17s)
=== RUN   TestUserLibrary_QueryShowsByTitle_Success
--- PASS: TestUserLibrary_QueryShowsByTitle_Success (0.20s)
=== RUN   TestUserLibrary_UpsertEpisode_Success
--- PASS: TestUserLibrary_UpsertEpisode_Success (0.39s)
=== RUN   TestUserLibrary_UpsertSeason_Success
--- PASS: TestUserLibrary_UpsertSeason_Success (0.41s)
=== RUN   TestUserLibrary_UpsertShow_Success
--- PASS: TestUserLibrary_UpsertShow_Success (0.41s)
--- PASS: TestUserLibrarySuite (9.67s)
PASS
```
