### PR TITLE
Add recursive file watcher

### DIFF
--- a/cmd/standalone/config-sample.json
+++ b/cmd/standalone/config-sample.json
@@ -5,5 +5,6 @@
     },
     "rethinkdb": {
         "address": "localhost"
-    }
+    },
+    "series_path": "/tmp/tvseries"
 }

--- a/cmd/standalone/config.go
+++ b/cmd/standalone/config.go
@@ -18,8 +18,9 @@ type RethinkConfig struct {
 
 // Config -
 type Config struct {
-	Trakt   *TraktConfig   `json:"trakt"`
-	Rethink *RethinkConfig `json:"rethinkdb"`
+	Trakt      *TraktConfig   `json:"trakt"`
+	Rethink    *RethinkConfig `json:"rethinkdb"`
+	SeriesPath string         `json:"series_path"`
 }
 
 func loadConfig(fp string) (*Config, error) {

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -78,7 +78,7 @@ func main() {
 
 	// trakt.tv client
 	trkt := trakt.NewClient(
-		traktClientID,
+		cfg.Trakt.ClientID,
 		trakt.TokenAuth{AccessToken: tok.AccessToken},
 	)
 

--- a/watcher.go
+++ b/watcher.go
@@ -18,7 +18,7 @@ const (
 type Watcher interface {
 	// Watch starts watching a directory or api
 	// or errors with ErrInternalServer
-	Watch(path string, recursive bool) error
+	Watch(dir string) error
 	// Notify adds Notifiees that want to be notified about file changes
 	Notify(WatcherNotifiee)
 }
@@ -26,5 +26,5 @@ type Watcher interface {
 // WatcherNotifiee is anything that wants to be notified about file changes
 type WatcherNotifiee interface {
 	// HandleWatcherNotification handles Watcher notifications
-	HandleWatcherNotification(notifType NotificationType, path string)
+	HandleWatcherNotification(notifType NotificationType, filepath string)
 }

--- a/watcher_file.go
+++ b/watcher_file.go
@@ -1,12 +1,62 @@
 package minutes
 
+import (
+	"log"
+
+	fsnotify "github.com/fsnotify/fsnotify"
+	recwatch "github.com/xyproto/recwatch"
+)
+
 // FileWatcher watches a directory and notifies Notifiees for file changes
-type FileWatcher struct{}
+type FileWatcher struct {
+	notifiees []WatcherNotifiee
+}
 
 // Watch starts watching a folder
 func (fw *FileWatcher) Watch(path string, recursive bool) error {
+	rw, err := recwatch.NewRecursiveWatcher(path)
+	if err != nil {
+		return err
+	}
+
+	defer rw.Close()
+
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case event := <-rw.Events:
+				log.Println("event:", event)
+				if event.Op&fsnotify.Create == fsnotify.Create {
+					fw.notify(NotificationFileCreated, event.Name)
+				} else if event.Op&fsnotify.Write == fsnotify.Write {
+					fw.notify(NotificationFileUpdated, event.Name)
+				} else if event.Op&fsnotify.Remove == fsnotify.Remove {
+					fw.notify(NotificationFileRemoved, event.Name)
+				}
+			case err := <-rw.Errors:
+				log.Println("Watcher returned an error:", err) // TODO(geoah) Better error handling
+			}
+		}
+	}()
+
+	err = rw.AddFolder(path)
+	if err != nil {
+		return err
+	}
+
+	<-done
+
 	return nil
 }
 
+func (fw *FileWatcher) notify(ntt NotificationType, path string) {
+	for _, ntf := range fw.notifiees {
+		ntf.HandleWatcherNotification(ntt, path)
+	}
+}
+
 // Notify registers a Notifiee to be notified about file updates
-func (fw *FileWatcher) Notify(WatcherNotifiee) {}
+func (fw *FileWatcher) Notify(wn WatcherNotifiee) {
+	fw.notifiees = append(fw.notifiees, wn)
+}

--- a/watcher_file.go
+++ b/watcher_file.go
@@ -2,9 +2,18 @@ package minutes
 
 import (
 	"log"
+	"os"
+	"path/filepath"
+	"regexp"
 
 	fsnotify "github.com/fsnotify/fsnotify"
 	recwatch "github.com/xyproto/recwatch"
+)
+
+var (
+	fileWatcherIgnoreRegexs = []*regexp.Regexp{
+		regexp.MustCompile(`.DS_Store$`),
+	}
 )
 
 // FileWatcher watches a directory and notifies Notifiees for file changes
@@ -13,8 +22,12 @@ type FileWatcher struct {
 }
 
 // Watch starts watching a folder
-func (fw *FileWatcher) Watch(path string, recursive bool) error {
-	rw, err := recwatch.NewRecursiveWatcher(path)
+func (fw *FileWatcher) Watch(dir string) error {
+	if err := fw.walk(dir); err != nil {
+		return err
+	}
+
+	rw, err := recwatch.NewRecursiveWatcher(dir)
 	if err != nil {
 		return err
 	}
@@ -26,21 +39,25 @@ func (fw *FileWatcher) Watch(path string, recursive bool) error {
 		for {
 			select {
 			case event := <-rw.Events:
-				log.Println("event:", event)
+				fp := event.Name
+				if fw.blacklisted(fp) {
+					continue
+				}
 				if event.Op&fsnotify.Create == fsnotify.Create {
-					fw.notify(NotificationFileCreated, event.Name)
+					fw.notify(NotificationFileCreated, fp)
 				} else if event.Op&fsnotify.Write == fsnotify.Write {
-					fw.notify(NotificationFileUpdated, event.Name)
+					fw.notify(NotificationFileUpdated, fp)
 				} else if event.Op&fsnotify.Remove == fsnotify.Remove {
-					fw.notify(NotificationFileRemoved, event.Name)
+					fw.notify(NotificationFileRemoved, fp)
 				}
 			case err := <-rw.Errors:
-				log.Println("Watcher returned an error:", err) // TODO(geoah) Better error handling
+				// TODO(geoah) Better error handling
+				log.Println("Watcher returned an error:", err)
 			}
 		}
 	}()
 
-	err = rw.AddFolder(path)
+	err = rw.AddFolder(dir)
 	if err != nil {
 		return err
 	}
@@ -50,10 +67,35 @@ func (fw *FileWatcher) Watch(path string, recursive bool) error {
 	return nil
 }
 
-func (fw *FileWatcher) notify(ntt NotificationType, path string) {
+// notify all notifiees about os file events
+func (fw *FileWatcher) notify(ntt NotificationType, fp string) {
 	for _, ntf := range fw.notifiees {
-		ntf.HandleWatcherNotification(ntt, path)
+		ntf.HandleWatcherNotification(ntt, fp)
 	}
+}
+
+// blacklisted files and directories
+func (fw *FileWatcher) blacklisted(fp string) bool {
+	if info, err := os.Stat(fp); err == nil && info.IsDir() {
+		return true
+	}
+	for _, rx := range fileWatcherIgnoreRegexs {
+		if mt := rx.MatchString(fp); mt {
+			return true
+		}
+	}
+	return false
+}
+
+// walk through a directory recursively and notifies all notifiees
+// about all found files and directories as NotificationFileCreated
+func (fw *FileWatcher) walk(dir string) error {
+	return filepath.Walk(dir, func(fp string, f os.FileInfo, err error) error {
+		if fw.blacklisted(fp) == false {
+			fw.notify(NotificationFileCreated, fp)
+		}
+		return nil
+	})
 }
 
 // Notify registers a Notifiee to be notified about file updates


### PR DESCRIPTION
This resolves #2 
### Changelog
- Add recursive file watcher on a folder.
- Add recursive walk through whole directory on start.
### Issues
- Currently the watcher walks through all files on start, we need a caching mechanism at some point to figure out what files have been processed and not process them again. #9
