### PR TITLE
Add interactive cli

### DIFF
--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -16,6 +16,7 @@ var log = logging.MustGetLogger("standalone")
 // daemon implements the WatchNotifier interface so it can be notified for
 // updates
 type daemon struct {
+	config     *Config
 	watcher    minutes.Watcher
 	glibrary   minutes.Library
 	ulibrary   minutes.Library
@@ -166,6 +167,7 @@ func main() {
 
 	// standalone daemon
 	daem := &daemon{
+		config:     cfg,
 		glibrary:   glib,
 		ulibrary:   ulib,
 		finder:     fndr,
@@ -179,9 +181,6 @@ func main() {
 	// notify daemon when something changes
 	wtch.Notify(daem)
 
-	// start watching for changes
-	wtch.Watch(cfg.SeriesPath)
-
-	// TODO run every x minutes check for missing episodes
-	daem.Diff()
+	// start shell
+	daem.startShell()
 }

--- a/cmd/standalone/shell.go
+++ b/cmd/standalone/shell.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	minutes "github.com/42minutes/go-42minutes"
+	ishell "github.com/abiosoft/ishell"
+)
+
+func (d *daemon) startShell() {
+	// configure our interactive shell
+	shell := ishell.New()
+	shell.Println("* 42minutes standalone client")
+
+	// register add function to add new series
+	shell.Register("add", func(args ...string) (string, error) {
+		tt := ""
+		if len(args) > 0 {
+			tt = strings.Join(args, " ")
+		}
+		shs, err := d.glibrary.QueryShowsByTitle(tt)
+		if err != nil || len(shs) == 0 {
+			return "Could not find series by name.", err
+		}
+
+		sh := shs[0]
+
+		if err := d.ulibrary.UpsertShow(sh); err != nil {
+			shell.Println()
+			return "Could not find series by name.", err
+		}
+
+		return fmt.Sprintf("Added '%s' to your library.", sh.Title), nil
+	})
+
+	// register function to add new series
+	shell.Register("add", func(args ...string) (string, error) {
+		tt := ""
+		if len(args) > 0 {
+			tt = strings.Join(args, " ")
+		}
+		shs, err := d.glibrary.QueryShowsByTitle(tt)
+		if err != nil || len(shs) == 0 {
+			return "Could not find any series matching the name you provided.", err
+		}
+
+		sh := shs[0]
+
+		if ush, err := d.ulibrary.GetShow(sh.ID); err != nil {
+			if err != minutes.ErrNotFound {
+				return "There was an issue getting the user's library.", err
+			}
+		} else if ush != nil {
+			return "You already have this series in your library.", nil
+		}
+
+		if err := d.ulibrary.UpsertShow(sh); err != nil {
+			shell.Println()
+			return "Could not find series by name.", err
+		}
+
+		return fmt.Sprintf("Added '%s' to your library.", sh.Title), nil
+	})
+
+	// register function to list series
+	shell.Register("list", func(args ...string) (string, error) {
+		shs, err := d.ulibrary.GetShows()
+		if err != nil {
+			return "There was an issue getting the user's library.", err
+		} else if len(shs) == 0 {
+			return "You do not have any shows in your library.", err
+		}
+
+		shell.Println(fmt.Sprintf("You have %d series.", len(shs)))
+
+		for _, sh := range shs {
+			shell.Println(fmt.Sprintf("> %s", sh.Title))
+		}
+
+		return "", nil
+	})
+
+	// register function to run diff
+	shell.Register("diff", func(args ...string) (string, error) {
+		shell.Println("Running diff...")
+		d.Diff()
+		return fmt.Sprintf("Diff completed."), nil
+	})
+
+	// register function to run watch
+	shell.Register("watch", func(args ...string) (string, error) {
+		pt := d.config.SeriesPath
+		if len(args) > 0 {
+			pt = strings.Join(args, " ")
+		}
+		shell.Println(fmt.Sprintf("Running a new watcher on %s.", pt))
+		d.watcher.Watch(pt)
+		return fmt.Sprintf("Watcher started."), nil
+	})
+
+	// start shell
+	shell.Start()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -28,6 +28,12 @@
 			"revisionTime": "2016-03-17T14:11:10Z"
 		},
 		{
+			"checksumSHA1": "ozIqn2GBGEE97uK8WFcliie/qtg=",
+			"path": "github.com/abiosoft/ishell",
+			"revision": "a7612be24192ddf96ba5f1fd5654d2e96a7553c7",
+			"revisionTime": "2016-10-04T15:53:07Z"
+		},
+		{
 			"checksumSHA1": "oLYnEHr1dTmo+QYudDHJJWNZ0a4=",
 			"origin": "github.com/42minutes/go-torrentlookup/vendor/github.com/andybalholm/cascadia",
 			"path": "github.com/andybalholm/cascadia",
@@ -63,6 +69,12 @@
 			"path": "github.com/dancannon/gorethink/types",
 			"revision": "6468f77f2e54184f2ff8fec0006c008ac9eca496",
 			"revisionTime": "2015-10-02T20:54:56Z"
+		},
+		{
+			"checksumSHA1": "VdXZPcDRHK1T7XjBu2KW8Mb8S6w=",
+			"path": "github.com/flynn/go-shlex",
+			"revision": "3f9db97f856818214da2e1057f8ad84803971cff",
+			"revisionTime": "2015-05-15T14:53:56Z"
 		},
 		{
 			"checksumSHA1": "nmc2qcdbg17Ny8tHeEDQuphV6jA=",
@@ -105,6 +117,12 @@
 			"path": "github.com/jtacoma/uritemplates",
 			"revision": "307ae868f90f4ee1b73ebe4596e0394237dacce8",
 			"revisionTime": "2016-07-02T15:35:54Z"
+		},
+		{
+			"checksumSHA1": "BoXdUBWB8UnSlFlbnuTQaPqfCGk=",
+			"path": "github.com/op/go-logging",
+			"revision": "970db520ece77730c7e4724c61121037378659d9",
+			"revisionTime": "2016-03-15T20:05:05Z"
 		},
 		{
 			"checksumSHA1": "iUBA/Ah5mbfWGvUdnYrgAm7QnLg=",
@@ -209,6 +227,12 @@
 			"path": "google.golang.org/appengine/urlfetch",
 			"revision": "267c27e7492265b84fc6719503b14a1e17975d79",
 			"revisionTime": "2016-06-21T05:59:22Z"
+		},
+		{
+			"checksumSHA1": "VAPpB3iZ9bfjWqNDoX7qXqfRcQU=",
+			"path": "gopkg.in/readline.v1",
+			"revision": "62c6fe6193755f722b8b8788aa7357be55a50ff1",
+			"revisionTime": "2016-07-26T13:51:17Z"
 		}
 	],
 	"rootPath": "github.com/42minutes/go-42minutes"


### PR DESCRIPTION
Resolves #17 
### Changelog
- Adds an interactive cli with the following commands
  - `list` - lists all user shows in user's library
  - `add show-name` - adds show based on name in user's library
  - `diff` - runs diff
  - `watch dir-path` - watches a directory recursively (if dir-path default to config value)
- Removes `diff` and `watch` from running on startup
